### PR TITLE
Added downloads counts

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -59,7 +59,7 @@ if (
 	}
 	$result = mysqli_query($connection,
 		'CREATE TABLE IF NOT EXISTS `'.$settings['db_prefix'].'torrents` (' .
-			//'`name` varchar(255) NOT NULL,' .			// it seems useless
+			'`name` varchar(255) NULL,' .
 			'`info_hash` varchar(40) NOT NULL,' .
 			'`downloads` int(10) unsigned NOT NULL DEFAULT \'0\',' .
 			'PRIMARY KEY (`info_hash`)' .

--- a/admin.php
+++ b/admin.php
@@ -59,8 +59,10 @@ if (
 	}
 	$result = mysqli_query($connection,
 		'CREATE TABLE IF NOT EXISTS `'.$settings['db_prefix'].'torrents` (' .
-			'`name` varchar(255) NOT NULL,' .
-			'`info_hash` varchar(40) NOT NULL' .
+			//'`name` varchar(255) NOT NULL,' .			// it seems useless
+			'`info_hash` varchar(40) NOT NULL,' .
+			'`downloads` int(10) unsigned NOT NULL DEFAULT \'0\',' .
+			'PRIMARY KEY (`info_hash`)' .
 		') ENGINE=MyISAM DEFAULT CHARSET=latin1'
 	);
 	if ( !$result ) {

--- a/function.peer.completed.php
+++ b/function.peer.completed.php
@@ -1,0 +1,28 @@
+<?php
+
+function peer_completed() {
+
+	global $connection, $settings;
+
+	require_once __DIR__.'/once.db.connect.php';
+
+	mysqli_query(
+		$connection,
+		'INSERT INTO `'.$settings['db_prefix'].'torrents` '.
+		'(`info_hash`, `downloads`) '.
+		'VALUES ('.
+			// 40-byte info_hash in HEX
+			'\''.$_GET['info_hash'].'\', '.
+			// initial value = 1
+			'1'.
+		') '.
+		'ON DUPLICATE KEY UPDATE '.
+			// if exists then increment
+			'`downloads`=`downloads`+1;'
+	);
+
+	// Silent fail
+	//tracker_error('Failed to update downloads count.');
+	return true;
+
+}

--- a/function.peer.event.php
+++ b/function.peer.event.php
@@ -34,6 +34,9 @@ function peer_event() {
 		} else if ( $_GET['event'] == 'completed' ) {
 			// Force Seeding Status
 			$settings['seeding'] = 1;
+			// Increment downloads
+			require_once __DIR__.'/function.peer.completed.php';
+			peer_completed();
 			// HOOK DOWNLOAD COMPLETE
 			if ( is_readable(__DIR__.'/hook.download.complete.php') ) {
 				include __DIR__.'/hook.download.complete.php';

--- a/function.torrent.scrape.php
+++ b/function.torrent.scrape.php
@@ -10,19 +10,20 @@ function torrent_scrape() {
 	// select seeders and leechers
 	$query = '
 		SELECT
-			`info_hash`,
-			SUM(`state`=\'1\') AS `seeders`,
-			SUM(`state`=\'0\') AS `leechers`
-		FROM `'.$settings['db_prefix'].'peers`
-		WHERE `info_hash`=\''.$_GET['info_hash'].'\';';
+			`p`.`info_hash` AS `info_hash`,
+			SUM(`p`.`state`=\'1\') AS `seeders`,
+			SUM(`p`.`state`=\'0\') AS `leechers`,
+			`t`.`downloads` AS `downloads`
+		FROM `'.$settings['db_prefix'].'peers` AS `p`
+			LEFT JOIN `'.$settings['db_prefix'].'torrents` AS `t`
+			ON `p`.`info_hash`=`t`.`info_hash`
+		WHERE `p`.`info_hash`=\''.$_GET['info_hash'].'\';';
 	$scrape = mysqli_fetch_once($query);
 
 	if ( !$scrape ) {
 		tracker_error('Unable to scrape for that torrent.');
 	} else {
 
-		// TODO Downloaded count.
-		$scrape['downloads'] = 0;
 		$scrape['seeders'] = intval($scrape['seeders']);
 		$scrape['leechers'] = intval($scrape['leechers']);
 		$scrape['downloads'] = intval($scrape['downloads']);

--- a/function.tracker.stats.php
+++ b/function.tracker.stats.php
@@ -19,6 +19,13 @@ function tracker_stats() {
 		'FROM `'.$settings['db_prefix'].'peers`'
 	);
 
+	// Downloads
+	$downloads = mysqli_fetch_once(
+		'SELECT '.
+		'SUM(`downloads`) AS `downloads` '.
+		'FROM `'.$settings['db_prefix'].'torrents`'
+	);
+
 	if ( !$stats ) {
 		tracker_error('Unable to get stats.');
 	} else {
@@ -28,9 +35,7 @@ function tracker_stats() {
 		$stats['seeders'] = intval($stats['seeders']);
 		$stats['leechers'] = intval($stats['leechers']);
 		$stats['torrents'] = intval($stats['torrents']);
-		// TODO Downloads (actual and in output)
-		$stats['downloads'] = 0;
-		// $stats['downloads'] = intval($stats['downloads']);
+		$stats['downloads'] = intval($downloads['downloads']);
 		$stats['peers'] = $stats['seeders']+$stats['leechers'];
 
 		// XML
@@ -41,7 +46,8 @@ function tracker_stats() {
 				 '<peers>'.$stats['peers'].'</peers>'.
 				 '<seeders>'.$stats['seeders'].'</seeders>'.
 				 '<leechers>'.$stats['leechers'].'</leechers>'.
-				 '<torrents>'.$stats['torrents'].'</torrents></tracker>';
+				 '<torrents>'.$stats['torrents'].'</torrents>'.
+				 '<downloads>'.$stats['downloads'].'</downloads></tracker>';
 
 		// JSON
 		} else if ( isset($_GET['json']) ) {
@@ -54,6 +60,7 @@ function tracker_stats() {
 							'seeders' => $stats['seeders'],
 							'leechers' => $stats['leechers'],
 							'torrents' => $stats['torrents'],
+							'downloads' => $stats['downloads'],
 						),
 					)
 				);
@@ -64,7 +71,8 @@ function tracker_stats() {
 					 '<title>Phoenix: $Id: '.$phoenix_version.' $</title>'.
 					 '<body><pre>'.number_format($stats['peers']).
 					 ' peers ('.number_format($stats['seeders']).' seeders + '.number_format($stats['leechers']).
-					 ' leechers) in '.number_format($stats['torrents']).' torrents</pre></body></html>';
+					 ' leechers) in '.number_format($stats['torrents']).' torrents and'.
+					 ' '.number_format($stats['downloads']).' downloads completed.</pre></body></html>';
 		}
 
 	}

--- a/once.db.connect.php
+++ b/once.db.connect.php
@@ -17,6 +17,10 @@ if (
 		tracker_error('Connection Failed. Tracker may be mis-configured. '.mysqli_connect_error($connection));
 	}
 
+	// SQL injection protection
+	$_GET['info_hash'] = mysqli_real_escape_string($connection, $_GET['info_hash']);
+	$_GET['peer_id']   = mysqli_real_escape_string($connection, $_GET['peer_id']);
+
 } else {
 	tracker_error('Connection Failed. Tracker is not configured.');
 }


### PR DESCRIPTION
Related issue: #10 
Added downloads count as asked.
Also added protection in 'info-hash' and 'peer_id' from sql injection (a 40 characters long info_hash was always concatenated without any filters). To check for vulnerabilities in another variables is recommended.
'name' column in 'torrents' table was disabled until you choose remove 'NOT NULL' or add 'DEFAULT'