### PR TITLE
IPv6 Support

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -34,15 +34,15 @@ if (
 		'CREATE TABLE IF NOT EXISTS `'.$settings['db_prefix'].'peers` (' .
 			'`info_hash` varchar(40) NOT NULL,' .
 			'`peer_id` varchar(40) NOT NULL,' .
-			'`compact` varchar(12) NOT NULL,' .
-			'`ip` char(15) NOT NULL,' .
-			'`ip6` char(39) NOT NULL DEFAULT \'0\',' .
-			'`port` smallint(5) unsigned NOT NULL,' .
-			'`port6` smallint(5) unsigned NOT NULL,' .
+			'`compactv4` varchar(12) NOT NULL,' .
+			'`compactv6` varchar(36) NOT NULL,' .
+			'`ipv4` char(15) NOT NULL DEFAULT \'0\',' .
+			'`ipv6` char(39) NOT NULL DEFAULT \'0\',' .
+			'`portv4` smallint(5) unsigned NOT NULL,' .
+			'`portv6` smallint(5) unsigned NOT NULL,' .
 			'`left` int(100) unsigned NOT NULL DEFAULT \'0\',' .
 			'`state` tinyint(1) unsigned NOT NULL DEFAULT \'0\',' .
-			'`updated` int(10) unsigned NOT NULL,' .
-			'PRIMARY KEY (`info_hash`,`peer_id`)' .
+			'`updated` int(10) unsigned NOT NULL' .
 		') ENGINE=MyISAM DEFAULT CHARSET=latin1'
 	);
 	if ( !$result ) {

--- a/admin.php
+++ b/admin.php
@@ -36,7 +36,9 @@ if (
 			'`peer_id` varchar(40) NOT NULL,' .
 			'`compact` varchar(12) NOT NULL,' .
 			'`ip` char(15) NOT NULL,' .
+			'`ip6` char(39) NOT NULL DEFAULT \'0\',' .
 			'`port` smallint(5) unsigned NOT NULL,' .
+			'`port6` smallint(5) unsigned NOT NULL,' .
 			'`left` int(100) unsigned NOT NULL DEFAULT \'0\',' .
 			'`state` tinyint(1) unsigned NOT NULL DEFAULT \'0\',' .
 			'`updated` int(10) unsigned NOT NULL,' .

--- a/announce.php
+++ b/announce.php
@@ -35,8 +35,6 @@ if (
 	tracker_error('Peer ID is invalid.');
 
 } else {
-	$stderr = fopen('php://stderr', 'w');
-
 	// Determine if the client is using IPv4 or IPv6
 
 	// If we're honoring X_FORWARDED_FOR, we check and use that first
@@ -63,8 +61,6 @@ if (
 	} else {
 		tracker_error('Unknown IP family!');
 	}
-
-	fwrite($stderr, "Got client IP: $client_ip and family $client_ip_family\n");
 
 	// Handle IP processing depending on our client family
 	if ( $client_ip_family === "ipv6" ) {
@@ -99,11 +95,6 @@ if (
 			validate_ipv6();
 		}
 	}
-
-	fwrite($stderr, "IPv4 addr: ".$_GET['ipv4'].'\n');
-	fwrite($stderr, "IPv4 port: ".$_GET['portv4'].'\n');
-	fwrite($stderr, "IPv6 addr: ".$_GET['ipv6'].'\n');
-	fwrite($stderr, "IPv6 port: ".$_GET['portv6'].'\n');
 
 	////	Left
 	// Optional

--- a/function.annouce.validate.php
+++ b/function.annouce.validate.php
@@ -1,0 +1,44 @@
+<?php
+
+function validate_ipv6() {
+	$stderr = fopen('php://stderr', 'w');
+
+	// If we get an IPv6 parameter, use that, else, use client's address
+	// The IPv6 address can either be in the form of:
+	// dead:beef::1234 - i.e., raw address, in which case we use port=
+	// -or-
+	// [dead:beef::1234]:12345 - i.e., enbedded port. Unfortunately
+	// PHP has no functions for handling IPv6 addresses so we'll
+	// have to roll our own
+
+	// Check the easy case first ..
+	if ( filter_var($_GET['ipv6'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
+		// Sweet, copy the port to port6, and we're done
+		if ( isset($_GET['port']) && is_numeric($_GET['port']) ) {
+			$_GET['portv6'] = $_GET['port'];
+		} else {
+			fwrite($stderr, "Bad port, bailing out\n");
+			tracker_error('Did not get port and was not specified via ipv6=');
+		}
+	} else {
+		// Nope. This just got considerably more annoying.
+		// Our first char must be '['
+		// FIXME: finish this
+		if ( $client_ip[0] ==! '[' ) {
+			tracker_error('Invalid IPv6 address');
+		}
+	}
+}
+
+function validate_ipv4() {
+	$_GET['ipv4'] = trim($_GET['ipv4'],'::ffff:');
+	if ( strpos($_GET['ipv4'], ':') !== false ) {
+		$_GET['ipv4'] = explode(':', $_GET['ipv4']);
+		$_GET['portv4'] = $_GET['ipv4'][1];
+		$_GET['ipv4'] = $_GET['ipv4'][0];
+	} else {
+		$_GET['portv4'] = $_GET['port'];
+	}
+}
+
+?>

--- a/function.annouce.validate.php
+++ b/function.annouce.validate.php
@@ -23,10 +23,38 @@ function validate_ipv6() {
 	} else {
 		// Nope. This just got considerably more annoying.
 		// Our first char must be '['
-		// FIXME: finish this
-		if ( $client_ip[0] ==! '[' ) {
+		if ( $_GET['ipv6'][0] ==! '[' ) {
 			tracker_error('Invalid IPv6 address');
 		}
+
+		$end_mark = strpos($_GET['ipv6'], ']')-1;
+		if ( !$end_mark ) {
+			tracker_error('Invalid IPv6 address');
+		}
+
+		$v6_addr = substr($_GET['ipv6'], 1, $end_mark);
+		if (! filter_var($v6_addr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
+			tracker_error('Invalid IPv6 address');
+		}
+
+		// Got the address, fish the port if its there
+		if ( (strlen($v6_adr)+2) == strlen($_GET['ipv6']) ) {
+			// Port wasn't included, copy it from port= if its there ...
+			if ( isset($_GET['port']) && is_numeric($_GET['port']) ) {
+				$_GET['portv6'] = $_GET['port'];
+			} else {
+				tracker_error('Invalid port specification');
+			}
+			$_GET['ipv6'] = $v6_addr;
+		}
+
+		// Try to get the port from the end of the string
+		$_GET['portv6'] = substr($_GET['ipv6'], strlen($v6_addr)+3);
+		$_GET['ipv6'] = $v6_addr;
+		if (!is_numeric($_GET['portv6'])) {
+			tracker_error('Invalid Port at end of v6 string');
+		}
+
 	}
 }
 

--- a/function.annouce.validate.php
+++ b/function.annouce.validate.php
@@ -1,8 +1,6 @@
 <?php
 
 function validate_ipv6() {
-	$stderr = fopen('php://stderr', 'w');
-
 	// If we get an IPv6 parameter, use that, else, use client's address
 	// The IPv6 address can either be in the form of:
 	// dead:beef::1234 - i.e., raw address, in which case we use port=
@@ -17,7 +15,6 @@ function validate_ipv6() {
 		if ( isset($_GET['port']) && is_numeric($_GET['port']) ) {
 			$_GET['portv6'] = $_GET['port'];
 		} else {
-			fwrite($stderr, "Bad port, bailing out\n");
 			tracker_error('Did not get port and was not specified via ipv6=');
 		}
 	} else {

--- a/function.peer.event.php
+++ b/function.peer.event.php
@@ -50,13 +50,18 @@ function peer_event() {
 		// No Existing Peer
 		!$peer ||
 		// IP has changed.
-		$peer['ip'] != $_GET['ip'] ||
+		$peer['ipv4'] != $_GET['ipv4'] ||
+		$peer['ipv6'] != $_GET['ipv6'] ||
 		// Port has changed.
-		$peer['port'] != $_GET['port'] ||
+		$peer['portv4'] != $_GET['portv4'] ||
+		$peer['portv6'] != $_GET['portv6'] ||
 		// check whether seeding status match
 		$peer['state'] != $settings['seeding']
 	) {
 		require_once __DIR__.'/function.peer.new.php';
+		require_once __DIR__.'/function.peer.delete.php';
+		// Delete and reload the peer
+		peer_delete();
 		peer_new();
 		// HOOK PEER NEW/CHANGE
 		if ( is_readable(__DIR__.'/hook.peer.change.php') ) {

--- a/function.peer.new.php
+++ b/function.peer.new.php
@@ -6,21 +6,33 @@ function peer_new() {
 
 	require_once __DIR__.'/once.db.connect.php';
 
+	$compactv4 = '';
+	$compactv6 = '';
+	if ( isset($_GET['ipv4'])) {
+		$compactv4 = bin2hex(pack('Nn', ip2long($_GET['ipv4']), $_GET['portv4']));
+	}
+	if ( isset($_GET['ipv6'])) {
+		$compactv6 = bin2hex( inet_pton($_GET['ipv6']) . pack('n', $_GET['portv6']) );
+	}
+
 	$peer_new = mysqli_query(
 		$connection,
 		'REPLACE INTO `'.$settings['db_prefix'].'peers` '.
-		'(`info_hash`, `peer_id`, `compact`, `ip`, `port`, `left`, `state`, `updated`) '.
+		'(`info_hash`, `peer_id`, `compactv4`, `compactv6`, `ipv4`, `ipv6`, `portv4`,`portv6`, `left`, `state`, `updated`) '.
 		'VALUES ('.
 			// 40-byte info_hash in HEX
 			'\''.$_GET['info_hash'].'\', '.
 			// 40-byte peer_id in HEX
 			'\''.$_GET['peer_id'].'\', '.
 			// 12-byte compacted peer info
-			'\''.bin2hex(pack('Nn', ip2long($_GET['ip']), $_GET['port'])).'\', '.
+			'\''.$compactv4.'\', '.
+			'\''.$compactv6.'\', '.
 			// dotted decimal string ip
-			'\''.$_GET['ip'].'\', '.
+			'\''.$_GET['ipv4'].'\', '.
+			'\''.$_GET['ipv6'].'\', '.
 			// integer port
-			'\''.$_GET['port'].'\', '.
+			'\''.$_GET['portv4'].'\', '.
+			'\''.$_GET['portv6'].'\', '.
 			// integer left
 			'\''.$_GET['left'].'\', '.
 			// integer state

--- a/function.torrent.announce.php
+++ b/function.torrent.announce.php
@@ -32,6 +32,7 @@ function torrent_announce() {
 	// IF Compact
 	if ( $_GET['compact'] ) {
 		$peers = '';
+		$peersv6 = '';
 	// END IF Compact
 
 	// IF Not Compact
@@ -47,17 +48,30 @@ function torrent_announce() {
 
 			// IF Compact
 			if ( $_GET['compact'] ) {
-				$peers .= hex2bin($peer['compact']);
+				if ( $peer['compact'] != null ) {
+					$peers .= hex2bin($peer['compact']);
+				}
+				if ( $peer['compactv6'] != null ) {
+					$peersv6 .= hex2bin($peer['compactv6']);
+				}
 			// END IF Compact
 
 			// IF No Peer ID
 			} else if ( $_GET['no_peer_id'] ) {
-				$response .= 'd2:ip'.strlen($peer['ip']).':'.$peer['ip'].'4:porti'.$peer['port'].'ee';
+				if ( $peer['ipv4'] != null ) {
+					$response .= 'd2:ip'.strlen($peer['ip']).':'.$peer['ip'].'4:porti'.$peer['portv4'].'ee';
+				} elseif ( $peer['ipv6'] != null ) {
+					$response .= 'd2:ip'.strlen($peer['ipv6']).':'.$peer['ipv6'].'4:porti'.$peer['portv6'].'ee';
+				}
 			// END IF No Peer ID
 
 			// IF Normal
 			} else {
-				$response .= 'd2:ip'.strlen($peer['ip']).':'.$peer['ip'].'7:peer id20:'.hex2bin($peer['peer_id']).'4:porti'.$peer['port'].'ee';
+				if ( $peer['ip'] != null ) {
+					$response .= 'd2:ip'.strlen($peer['ipv4']).':'.$peer['ipv4'].'7:peer id20:'.hex2bin($peer['peer_id']).'4:porti'.$peer['portv4'].'ee';
+				} elseif ( $peer['ipv6'] != null ) {
+					$response .= 'd2:ip'.strlen($peer['ipv6']).':'.$peer['ipv6'].'7:peer id20:'.hex2bin($peer['peer_id']).'4:porti'.$peer['portv6'].'ee';
+				}
 			} // END IF Normal
 
 		}
@@ -67,6 +81,7 @@ function torrent_announce() {
 	if ( $_GET['compact'] ) {
 		// 6-byte compacted peer info
 		$response .= strlen($peers).':'.$peers;
+		$response .= '6:peers6'.strlen($peersv6).':'.$peersv6;
 	// END IF Compact
 
 	// IF Not Compact

--- a/settings.default.php
+++ b/settings.default.php
@@ -23,6 +23,10 @@ $settings = array(
 	'clean_idle_peers'  => 10,           /* tweaks % of time tracker attempts idle peer removal */
 	                                     /* if you have a busy tracker, you may adjust this */
 	                                     /* example: 1 = 1%, 10 = 10%, 50 = 50%, 100 = every time */
+	'honor_xff'        => false,          /* If this server is behind a frontend proxy, the client IP */
+					     /* will come in the form of a X-Forwarded-For. This option */
+					     /* should only be set if your frontend proxy properly handles */
+					     /* and filters XFF, else it allows for trivial IP spoofing */
 
 	// General Database Options
 	// Can be better overridden with a settings.custom.php file.


### PR DESCRIPTION
Closes #3.

 Adds IPv6 support to Phoenix BT tracker. 
Tested with RFC IP addresses.
Tested with IPv4-only, and mixed IPv4/v6 hosts
Handles seperate v4/v6 ports.
Properly senses inbound connection 
Option to disable X-Forwarded-For support (security risk)